### PR TITLE
Add libexecinfo

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -39,6 +39,7 @@ RUN apk add --no-cache \
     glib \
     gmp \
     iperf3 \
+    libexecinfo \
     libsodium \
     libwebp \
     libxml2 \


### PR DESCRIPTION
If needed for TensorFlow or other libs with more glibc exec stuff inside.

Size: 80 kB