### PR TITLE
feature enhancement:  add native picotts library to docker image so offline TTS (text-to-speech) option is available by default

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -100,6 +100,10 @@ RUN apk add --no-cache \
     && apk del .build-dependencies \
     && rm -rf /usr/src/arp-scan
 
+# PicoTTS
+RUN apk add --no-cache \
+        picotts --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing
+
 # Telldus
 RUN apk add --no-cache \
         confuse \


### PR DESCRIPTION
add one single line to Dockerfile to include picotts library

https://community.home-assistant.io/t/integrate-native-picotts-library-into-hass-io-home-assistant-docker-image/186309/4

https://github.com/home-assistant/docker/issues/114