### PR TITLE
Include zbar component packages to enable qr code

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,8 @@ RUN \
         pulseaudio-utils \
         socat \
         unixodbc \
-        zlib
+        zlib \
+        zbar
 
 ####
 ## Install pip module for component/homeassistant


### PR DESCRIPTION
When attempting to run the qr_code recieving "Platform error image_processing.qrcode - Unable to find zbar shared library" after logging into the docker image and installing zbar did the trick. Previously this package was not available but is in the community repository. 

https://pkgs.alpinelinux.org/package/edge/community/aarch64/zbar