### PR TITLE
Expose port 8123

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,9 @@ FROM ${BUILD_FROM}
 ARG BUILD_ARCH
 ENV WHEELS_LINKS=https://wheels.home-assistant.io/alpine-3.12/${BUILD_ARCH}/
 
+# Expose default frontend port
+EXPOSE 8123
+
 ####
 # Install core
 RUN \


### PR DESCRIPTION
This is useful for docker managers and reverse proxies like Traefik which monitor the docker socket.