### PR TITLE
Add libgpiod to support adafruit-circuitpython-dht

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,7 @@ RUN \
         gmp \
         iperf3 \
         libexecinfo \
+        libgpiod \
         libpcap \
         libsodium \
         libwebp \


### PR DESCRIPTION
Adding libgpiod to docker image to support the adafruit-circuitpython-dht library as the current used Adafruit-DHT is deprecated.
This should go with https://github.com/home-assistant/core/pull/41525