### PR TITLE
Add Oracle DB libraries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -154,6 +154,28 @@ RUN \
     && apk del .build-dependencies \
     && rm -rf /usr/src/telldus
 
+#Oracle Instant Client Basic
+RUN if [ "$BUILD_ARCH" = "aarch64" ] || [ "$BUILD_ARCH" = "amd64" ] || [ "$BUILD_ARCH" = "i386" ]; then \
+        if [ "$BUILD_ARCH" = "aarch64" ]; then \
+            instantclient_arch="-arm64"; \
+        elif [ "$BUILD_ARCH" = "amd64" ]; then \
+            instantclient_arch="x64"; \
+        elif [ "$BUILD_ARCH" = "i386" ]; then \
+            instantclient_arch=""; \
+        fi && \
+        apk add --no-cache --virtual=.build-dependencies libarchive-tools && \
+        #Permanent link to the latest package
+        wget https://download.oracle.com/otn_software/linux/instantclient/instantclient-basiclite-linux${instantclient_arch}.zip && \
+        bsdtar --strip-components=1 -xvf instantclient-basiclite-linux${instantclient_arch}.zip -C /lib && \
+        rm -rf instantclient-basiclite-linux${instantclient_arch}.zip &&  \
+        apk add libaio libnsl libc6-compat && \
+        cd /lib && \
+        ln -s /lib64/* /lib && \
+        ln -s libnsl.so.2 /usr/lib/libnsl.so.1 && \
+        ln -s libc.so.6 /lib/libresolv.so.2 && \
+        apk del .build-dependencies; \
+    fi
+
 ###
 # Base S6-Overlay
 COPY rootfs /

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ cchardet==2.1.7
 mysqlclient==2.0.3
 psycopg2==2.8.6
 pyodbc==4.0.30
-cx_Oracle==8.2.0
+cx_oracle==8.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ cchardet==2.1.7
 mysqlclient==2.0.3
 psycopg2==2.8.6
 pyodbc==4.0.30
+cx_Oracle==8.2.0


### PR DESCRIPTION
Following home-assistant/core#50090 I would like to add cx_oracle and Oracle Instant Client libraries to docker image to be able to use recorder with Oracle DB out of the box.