### PR TITLE
Add yaml to support pyyaml C loader

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN \
         libjpeg-turbo \
         libpng \
         libstdc++ \
+        yaml \
         musl \
         openssl \
         pulseaudio-alsa \


### PR DESCRIPTION
Replaces #232 since we only need the runtime not the `-dev` version

Needed for https://github.com/home-assistant/core/pull/73337