### PR TITLE
musllinux commit removed openssl binaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ RUN \
         net-tools \
         nmap \
         openssh-client \
+        openssl \
         pianobar \
         pulseaudio-alsa \
         socat


### PR DESCRIPTION
It was really handy to have the openssl binary in the container to do SSL cert validation, this commit adds it back after it was removed in e23abd3ad612bc81212cdad9084ebe6c2640f44f