### PR TITLE
Replace abandoned cchardet library

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Brotli==1.0.9
-cchardet==2.1.7
+faust-cchardet==2.1.16
 mysqlclient==2.1.1
 psycopg2==2.9.5


### PR DESCRIPTION
cchardet is abandoned https://docs.aiohttp.org/en/stable/#library-installation https://github.com/PyYoshi/cChardet/issues/77

There is a new active fork https://github.com/faust-streaming/cChardet that works on python3.11

https://github.com/home-assistant/core/pull/88254 will remove the last lib that uses it from core which we can merge when we bump this.