### PR TITLE
Drop arp-scan

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ ARG \
     BUILD_ARCH \
     QEMU_CPU \
     SSOCR_VERSION \
-    ARPSCAN_VERSION \
     LIBCEC_VERSION \
     PICOTTS_HASH \
     TELLDUS_COMMIT
@@ -63,24 +62,6 @@ RUN \
     && make install \
     && apk del .build-dependencies \
     && rm -rf /usr/src/ssocr
-
-# arp-scan
-RUN \
-    apk add --no-cache \
-        libpcap \
-    && apk add --no-cache --virtual .build-dependencies \
-        autoconf \
-        automake \
-        build-base \
-        libpcap-dev \
-    && git clone --depth 1 -b ${ARPSCAN_VERSION} https://github.com/royhills/arp-scan \
-    && cd arp-scan \
-    && autoreconf --install \
-    && ./configure \
-    && make -j$(nproc) \
-    && make install \
-    && apk del .build-dependencies \
-    && rm -rf /usr/src/arp-scan
 
 # libcec
 COPY patches/libcec-fix-null-return.patch /usr/src/

--- a/build.yaml
+++ b/build.yaml
@@ -20,7 +20,6 @@ labels:
   org.opencontainers.image.licenses: Apache License 2.0
 args:
   SSOCR_VERSION: 2.22.1
-  ARPSCAN_VERSION: 1.9.7
   LIBCEC_VERSION: 6.0.2
   TELLDUS_COMMIT: 2598bbed16ffd701f2a07c99582f057a3decbaf3
   PICOTTS_HASH: e3ba46009ee868911fa0b53db672a55f9cc13b1c


### PR DESCRIPTION
This PR drops arp-scan from our base images.

I could not find a single reference in the current Core codebase, nor could I find anything in the history. It seems this was added with the intention of doing something with it but was never put to use.

As it was custom built as well, it is a waste of build time, image size and maintenance to keep around. If it turns our to be used, it is available as Alpine `apk` nowadays, so we can re-add it easy and quickly if it turns out to be needed. (without building our own).

Ref PRs: #30, #31