### PR TITLE
Add hwdata-usb to base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN \
         iperf3 \
         git \
         grep \
+        hwdata-usb \
         libgpiod \
         libjpeg-turbo \
         libpulse \
@@ -35,8 +36,7 @@ RUN \
         openssh-client \
         pianobar \
         pulseaudio-alsa \
-        socat \
-        usbutils
+        socat
 
 ####
 ## Install pip module for component/homeassistant

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,8 @@ RUN \
         openssh-client \
         pianobar \
         pulseaudio-alsa \
-        socat
+        socat \
+        usbutils
 
 ####
 ## Install pip module for component/homeassistant


### PR DESCRIPTION
This PR adds the `hwdata-usb` package to our Home Assistant base image.

Currently, we install the `usbutils` package is installed in every machine image separately, while we only need `hwdata-usb`, so adding it to the base image, allows us to remove it from all machine images.

Ref: https://github.com/home-assistant/core/tree/f903c536fbae7b207c42a01db35968b10cfc3619/machine

Needed for: <https://github.com/home-assistant/core/pull/91942>
