### PR TITLE
Bump base image to use Python 3.11

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,11 +1,11 @@
 image: homeassistant/{arch}-homeassistant-base
 shadow_repository: ghcr.io/home-assistant
 build_from:
-  aarch64: ghcr.io/home-assistant/aarch64-base-python:3.10-alpine3.17
-  armhf: ghcr.io/home-assistant/armhf-base-python:3.10-alpine3.17
-  armv7: ghcr.io/home-assistant/armv7-base-python:3.10-alpine3.17
-  amd64: ghcr.io/home-assistant/amd64-base-python:3.10-alpine3.17
-  i386: ghcr.io/home-assistant/i386-base-python:3.10-alpine3.17
+  aarch64: ghcr.io/home-assistant/aarch64-base-python:3.11-alpine3.17
+  armhf: ghcr.io/home-assistant/armhf-base-python:3.11-alpine3.17
+  armv7: ghcr.io/home-assistant/armv7-base-python:3.11-alpine3.17
+  amd64: ghcr.io/home-assistant/amd64-base-python:3.11-alpine3.17
+  i386: ghcr.io/home-assistant/i386-base-python:3.11-alpine3.17
 codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io


### PR DESCRIPTION
Aimed for Home Assistant 2023.6, bump to use Python 3.11