### PR TITLE
Fix building libcec for Python 3.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,8 +82,8 @@ RUN apk add --no-cache \
     && mkdir build \
     && cd build \
     && cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr/local \
-        -DPYTHON_LIBRARY="/usr/local/lib/libpython3.10.so" \
-        -DPYTHON_INCLUDE_DIR="/usr/local/include/python3.10" \
+        -DPYTHON_LIBRARY="/usr/local/lib/libpython3.11.so" \
+        -DPYTHON_INCLUDE_DIR="/usr/local/include/python3.11" \
         -DHAVE_LINUX_API=1 \
         .. \
     && make -j"$(nproc)" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -88,7 +88,7 @@ RUN apk add --no-cache \
         .. \
     && make -j"$(nproc)" \
     && make install \
-    && echo "cec" > "/usr/local/lib/python3.10/site-packages/cec.pth" \
+    && echo "cec" > "/usr/local/lib/python3.11/site-packages/cec.pth" \
     && apk del .build-dependencies \
     && rm -rf \
         /usr/src/libcec \


### PR DESCRIPTION
Fixes a missed change in #273, adjust building libcec for Python 3.11

Tested locally, it passes now.