### PR TITLE
Bump base image to use Alpine Linux 3.18

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,11 +1,11 @@
 image: homeassistant/{arch}-homeassistant-base
 shadow_repository: ghcr.io/home-assistant
 build_from:
-  aarch64: ghcr.io/home-assistant/aarch64-base-python:3.11-alpine3.17
-  armhf: ghcr.io/home-assistant/armhf-base-python:3.11-alpine3.17
-  armv7: ghcr.io/home-assistant/armv7-base-python:3.11-alpine3.17
-  amd64: ghcr.io/home-assistant/amd64-base-python:3.11-alpine3.17
-  i386: ghcr.io/home-assistant/i386-base-python:3.11-alpine3.17
+  aarch64: ghcr.io/home-assistant/aarch64-base-python:3.11-alpine3.18
+  armhf: ghcr.io/home-assistant/armhf-base-python:3.11-alpine3.18
+  armv7: ghcr.io/home-assistant/armv7-base-python:3.11-alpine3.18
+  amd64: ghcr.io/home-assistant/amd64-base-python:3.11-alpine3.18
+  i386: ghcr.io/home-assistant/i386-base-python:3.11-alpine3.18
 codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io


### PR DESCRIPTION
SSIA, updates the base image to be based on Alpine Linux 3.18.

Caveat: Alpine Linux ships with ffmpeg 6, which is incompatible with pyav. However, since we build wheels on Alpine 3.17, those libraries are bundled and provided by Alpine 3.17 in the wheels and should not cause issues.