### PR TITLE
Build libgpiod Python bindings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -145,7 +145,7 @@ RUN \
         /usr/src/telldus-fix-gcc-11-issues.patch \
         /usr/src/telldus-fix-alpine-3-17-issues.patch
 
-# libgpiod Python bindings build against our Python 3.11
+# libgpiod Python bindings built against our Python 3.11
 RUN \
     apk add --no-cache --virtual .build-dependencies \
         autoconf \

--- a/Dockerfile
+++ b/Dockerfile
@@ -146,6 +146,7 @@ RUN \
         /usr/src/telldus-fix-alpine-3-17-issues.patch
 
 # libgpiod Python bindings built against our Python 3.11
+SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 RUN \
     apk add --no-cache --virtual .build-dependencies \
         autoconf \

--- a/Dockerfile
+++ b/Dockerfile
@@ -171,7 +171,8 @@ RUN \
         --with-python_prefix=/usr/local \
     && make \
     && cp bindings/python/.libs/gpiod.so /usr/local/lib/python3.11/site-packages \
-    && apk del .build-dependencies
+    && apk del .build-dependencies \
+    && rm -rf /usr/src/libgpiod
 
 ###
 # Base S6-Overlay

--- a/Dockerfile
+++ b/Dockerfile
@@ -149,6 +149,7 @@ RUN \
 SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 RUN \
     apk add --no-cache --virtual .build-dependencies \
+        build-base \
         autoconf \
         automake \
         libtool \

--- a/Dockerfile
+++ b/Dockerfile
@@ -144,6 +144,35 @@ RUN \
         /usr/src/telldus \
         /usr/src/telldus-fix-gcc-11-issues.patch \
         /usr/src/telldus-fix-alpine-3-17-issues.patch
+
+# libgpiod Python bindings build against our Python 3.11
+RUN \
+    apk add --no-cache --virtual .build-dependencies \
+        autoconf \
+        automake \
+        libtool \
+        linux-headers \
+        autoconf-archive \
+        python3-dev \
+        doxygen \
+        help2man \
+    && LIBGPIOD_VERSION=$(apk info -e -v libgpiod | awk -F '-' '{print $(NF-1)}') \
+    && git clone --depth=1 --branch="v$LIBGPIOD_VERSION" https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git \
+    && cd libgpiod \
+    && autoreconf -vfi \
+    && ./configure \
+        --prefix=/usr \
+        --sysconfdir=/etc \
+        --mandir=/usr/share/man \
+        --localstatedir=/var \
+        --enable-tools=yes \
+        --disable-static \
+        --enable-bindings-python \
+        --with-python_prefix=/usr/local \
+    && make \
+    && cp bindings/python/.libs/gpiod.so /usr/local/lib/python3.11/site-packages \
+    && apk del .build-dependencies
+
 ###
 # Base S6-Overlay
 COPY rootfs /


### PR DESCRIPTION
Rationale: I'm working on a Core PR that detects when the Yellow's CM4 module is unseated, which requires reading a few GPIO pins at runtime in Core. [`libgpiod` and its Python bindings](https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git/about/) seems to be the best way to do this, since it can be included in the base Home Assistant image and isn't specific to the Pi/CM4.

---

The `libgpiod` Alpine package's Python bindings (`py3-libgpiod`) are built against Alpine's default Python 3.11 package and won't install without pulling in the duplicate Python installation, nor is the resulting C extension placed in our Python's `site-packages`. I've added a new stage replicating the Alpine `APKBUILD` to re-compile the bindings against our system Python and copy just the single C extension into the `site-packages` folder.

A simpler alternative to this PR would be to temporarily install `py3-libgpiod` and copy the `.so` from `/usr/lib/python3.11/...` to `/usr/local/lib/python3.11`, but I'm not sure if Python C extensions are portable across installs in this way. Anecdotally, this worked for me on the Yellow.