### PR TITLE
Upgrade to Python 3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,13 +79,13 @@ RUN apk add --no-cache \
     && mkdir build \
     && cd build \
     && cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr/local \
-        -DPYTHON_LIBRARY="/usr/local/lib/libpython3.11.so" \
-        -DPYTHON_INCLUDE_DIR="/usr/local/include/python3.11" \
+        -DPYTHON_LIBRARY="/usr/local/lib/libpython3.12.so" \
+        -DPYTHON_INCLUDE_DIR="/usr/local/include/python3.12" \
         -DHAVE_LINUX_API=1 \
         .. \
     && make -j"$(nproc)" \
     && make install \
-    && echo "cec" > "/usr/local/lib/python3.11/site-packages/cec.pth" \
+    && echo "cec" > "/usr/local/lib/python3.12/site-packages/cec.pth" \
     && apk del .build-dependencies \
     && rm -rf \
         /usr/src/libcec \

--- a/build.yaml
+++ b/build.yaml
@@ -1,10 +1,10 @@
 image: ghcr.io/home-assistant/{arch}-homeassistant-base
 build_from:
-  aarch64: ghcr.io/home-assistant/aarch64-base-python:3.11-alpine3.18
-  armhf: ghcr.io/home-assistant/armhf-base-python:3.11-alpine3.18
-  armv7: ghcr.io/home-assistant/armv7-base-python:3.11-alpine3.18
-  amd64: ghcr.io/home-assistant/amd64-base-python:3.11-alpine3.18
-  i386: ghcr.io/home-assistant/i386-base-python:3.11-alpine3.18
+  aarch64: ghcr.io/home-assistant/aarch64-base-python:3.12-alpine3.18
+  armhf: ghcr.io/home-assistant/armhf-base-python:3.12-alpine3.18
+  armv7: ghcr.io/home-assistant/armv7-base-python:3.12-alpine3.18
+  amd64: ghcr.io/home-assistant/amd64-base-python:3.12-alpine3.18
+  i386: ghcr.io/home-assistant/i386-base-python:3.12-alpine3.18
 codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io


### PR DESCRIPTION
SSIA, we are on `aiohttp` 3.9.1 on both Supervisor and Core, removing the blockers to move to Python 3.12.

We are very early in the current development cycle, so that should be a good time to move.