### PR TITLE
Update base image to use Python 3.12.1 & Alpine 3.19

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -83,7 +83,7 @@ jobs:
         run: echo "BUILD_ARGS=--test" >> $GITHUB_ENV
 
       - name: Build base image
-        uses: home-assistant/builder@2023.12.0
+        uses: home-assistant/builder@2024.01.0
         with:
           args: |
             $BUILD_ARGS \

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -59,12 +59,12 @@ jobs:
             echo "changed=true" >> $GITHUB_OUTPUT
           fi
 
-      - name: Build wheels cp311
+      - name: Build wheels cp312
         uses: home-assistant/wheels@2023.10.5
         if: steps.requirements.outputs.changed == 'true'
         with:
           tag: musllinux_1_2
-          abi: cp311
+          abi: cp312
           arch: ${{ matrix.arch }}
           wheels-key: ${{ secrets.WHEELS_KEY }}
           apk: "mariadb-dev;postgresql-dev;libffi-dev"

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,13 +79,13 @@ RUN apk add --no-cache \
     && mkdir build \
     && cd build \
     && cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr/local \
-        -DPYTHON_LIBRARY="/usr/local/lib/libpython3.11.so" \
-        -DPYTHON_INCLUDE_DIR="/usr/local/include/python3.11" \
+        -DPYTHON_LIBRARY="/usr/local/lib/libpython3.12.so" \
+        -DPYTHON_INCLUDE_DIR="/usr/local/include/python3.12" \
         -DHAVE_LINUX_API=1 \
         .. \
     && make -j"$(nproc)" \
     && make install \
-    && echo "cec" > "/usr/local/lib/python3.11/site-packages/cec.pth" \
+    && echo "cec" > "/usr/local/lib/python3.12/site-packages/cec.pth" \
     && apk del .build-dependencies \
     && rm -rf \
         /usr/src/libcec \

--- a/build.yaml
+++ b/build.yaml
@@ -1,10 +1,10 @@
 image: ghcr.io/home-assistant/{arch}-homeassistant-base
 build_from:
-  aarch64: ghcr.io/home-assistant/aarch64-base-python:3.11-alpine3.18
-  armhf: ghcr.io/home-assistant/armhf-base-python:3.11-alpine3.18
-  armv7: ghcr.io/home-assistant/armv7-base-python:3.11-alpine3.18
-  amd64: ghcr.io/home-assistant/amd64-base-python:3.11-alpine3.18
-  i386: ghcr.io/home-assistant/i386-base-python:3.11-alpine3.18
+  aarch64: ghcr.io/home-assistant/aarch64-base-python:3.12-alpine3.19
+  armhf: ghcr.io/home-assistant/armhf-base-python:3.12-alpine3.19
+  armv7: ghcr.io/home-assistant/armv7-base-python:3.12-alpine3.19
+  amd64: ghcr.io/home-assistant/amd64-base-python:3.12-alpine3.19
+  i386: ghcr.io/home-assistant/i386-base-python:3.12-alpine3.19
 codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io


### PR DESCRIPTION
- Updates our Python environment to Python 3.12.1
- Update Alpine Linux to 3.19
- Update home-assistant/builder to 2024.01.0

Needs: <https://github.com/home-assistant/docker-base/actions/runs/7407595324>
Note: This PR has a 🐔 🥚 problem. Required wheels are build once this is in 😬