### PR TITLE
Update ssocr to 2.23.1

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -21,7 +21,7 @@ labels:
   org.opencontainers.image.documentation: https://www.home-assistant.io/docs/
   org.opencontainers.image.licenses: Apache License 2.0
 args:
-  SSOCR_VERSION: 2.22.1
+  SSOCR_VERSION: 2.23.1
   LIBCEC_VERSION: 6.0.2
   TELLDUS_COMMIT: 2598bbed16ffd701f2a07c99582f057a3decbaf3
   PICOTTS_HASH: e3ba46009ee868911fa0b53db672a55f9cc13b1c


### PR DESCRIPTION
Recent versions include a new `--min-char-dims` option to specify minimum character dimensions.