### PR TITLE
Switch libjpeg-turbo to its new name libturbojpeg for alpine 3.19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN \
         grep \
         hwdata-usb \
         libgpiod \
-        libjpeg-turbo \
+        libturbojpeg \
         libpulse \
         libzbar \
         mariadb-connector-c \


### PR DESCRIPTION
Reported in beta channel

```
homeassistant:/config# apk add libjpeg-turbo
fetch https://dl-cdn.alpinelinux.org/alpine/v3.19/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.19/community/x86_64/APKINDEX.tar.gz
OK: 1253 MiB in 239 packages
homeassistant:/config# apk add libturbojpeg
(1/1) Installing libturbojpeg (3.0.1-r0)
OK: 1254 MiB in 240 packages
homeassistant:/config# 
```