### PR TITLE
Update docker base image to Alpine 3.21

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,10 +1,10 @@
 image: ghcr.io/home-assistant/{arch}-homeassistant-base
 build_from:
-  aarch64: ghcr.io/home-assistant/aarch64-base-python:3.13-alpine3.20
-  armhf: ghcr.io/home-assistant/armhf-base-python:3.13-alpine3.20
-  armv7: ghcr.io/home-assistant/armv7-base-python:3.13-alpine3.20
-  amd64: ghcr.io/home-assistant/amd64-base-python:3.13-alpine3.20
-  i386: ghcr.io/home-assistant/i386-base-python:3.13-alpine3.20
+  aarch64: ghcr.io/home-assistant/aarch64-base-python:3.13-alpine3.21
+  armhf: ghcr.io/home-assistant/armhf-base-python:3.13-alpine3.21
+  armv7: ghcr.io/home-assistant/armv7-base-python:3.13-alpine3.21
+  amd64: ghcr.io/home-assistant/amd64-base-python:3.13-alpine3.21
+  i386: ghcr.io/home-assistant/i386-base-python:3.13-alpine3.21
 codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io


### PR DESCRIPTION
Updates our base image to the latest greatest, including the bump to Alpine 3.21, but also contains Python 3.13.1

https://github.com/home-assistant/docker-base/releases/tag/2024.12.0
https://github.com/home-assistant/docker-base/releases/tag/2024.12.1
https://github.com/home-assistant/docker-base/compare/2024.11.0...2024.12.1

