### PR TITLE
Use ubuntu-22.04 to build images

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   init:
     name: Initialize build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       architectures: ${{ steps.info.outputs.architectures }}
       version: ${{ steps.version.outputs.version }}
@@ -35,7 +35,7 @@ jobs:
   build:
     name: Build ${{ matrix.arch }} base image
     needs: init
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
We are hitting a QEMU issue with the latest kernel used in the ubuntu-latest runners.

Adjusting the CI to use `ubuntu-22.04` instead for now, same as done in https://github.com/home-assistant/docker-base/pull/294/

CI Failure: https://github.com/home-assistant/docker/actions/runs/13377608355/job/37360804008