### PR TITLE
Split up library builds into individual builder stages to preserve layer cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,132 +1,108 @@
 ARG BUILD_FROM
-FROM ${BUILD_FROM}
-
-ARG \
-    BUILD_ARCH \
-    QEMU_CPU \
-    SSOCR_VERSION \
-    LIBCEC_VERSION \
-    PICOTTS_HASH \
-    TELLDUS_COMMIT
-
-##
-# Install component packages
-RUN \
-    apk add --no-cache \
-        bluez \
-        bluez-deprecated \
-        bluez-libs \
-        curl \
-        eudev-libs \
-        ffmpeg \
-        iperf3 \
-        git \
-        grep \
-        hwdata-usb \
-        libgpiod \
-        libturbojpeg \
-        libpulse \
-        libzbar \
-        mariadb-connector-c \
-        net-tools \
-        nmap \
-        openssh-client \
-        pianobar \
-        pulseaudio-alsa \
-        socat
-
 ####
-## Install pip module for component/homeassistant
-COPY requirements.txt /usr/src/
-RUN \
-    pip3 install --only-binary=:all: \
-        -r /usr/src/requirements.txt \
-    && rm -f /usr/src/requirements.txt
-
-####
-## Build library
-WORKDIR /usr/src/
-
-# ssocr
-RUN \
-    apk add --no-cache \
-        imlib2 \
-    && apk add --no-cache --virtual .build-dependencies \
+## Builder stage for ssocr, installs to /opt/ssocr
+FROM ${BUILD_FROM} AS ssocr-builder
+ARG SSOCR_VERSION
+ARG BUILD_FROM
+WORKDIR /tmp/
+RUN --mount=type=cache,target=/etc/apk/cache,sharing=locked,id=ssocr-builder-${BUILD_FROM}-${SSOCR_VERSION} \
+    apk add \
         build-base \
         imlib2-dev \
-    && git clone --depth 1 -b "v${SSOCR_VERSION}" https://github.com/auerswal/ssocr \
-    && cd ssocr \
+    && mkdir /opt/ssocr /tmp/ssocr \
+    && curl --silent --fail --location "https://github.com/auerswal/ssocr/archive/refs/tags/v${SSOCR_VERSION}.tar.gz" \
+            | tar zxv -C /tmp/ssocr --strip-components 1 \
+    && cd /tmp/ssocr \
     && make -j"$(nproc)" \
-    && make install \
-    && apk del .build-dependencies \
-    && rm -rf /usr/src/ssocr
+    && make PREFIX=/opt/ssocr install \
+    && rm -rf /tmp/ssocr
 
-# libcec
-COPY patches/libcec-fix-null-return.patch /usr/src/
-COPY patches/libcec-python313.patch /usr/src/
-RUN apk add --no-cache \
-        eudev-libs \
-        p8-platform \
-    && apk add --no-cache --virtual .build-dependencies \
+
+####
+## Install pip module for component/homeassistant. Installs to /root/.local
+FROM ${BUILD_FROM} AS pip-install-builder
+ARG BUILD_FROM
+WORKDIR /tmp/
+COPY requirements.txt /tmp/requirements.txt
+RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked,id=pip-builder-${BUILD_FROM} \
+    pip3 install --user --only-binary=:all: \
+        -r /tmp/requirements.txt
+
+
+####
+## Builder stage for libcec, installs to /opt/libcec
+FROM ${BUILD_FROM} AS libcec-builder
+ARG LIBCEC_VERSION
+ARG BUILD_FROM
+WORKDIR /tmp/
+COPY patches/libcec-fix-null-return.patch /tmp/
+COPY patches/libcec-python313.patch /tmp/
+RUN --mount=type=cache,target=/etc/apk/cache,sharing=locked,id=libcec-builder-${BUILD_FROM}-${LIBCEC_VERSION} \
+    apk add  \
         build-base \
         cmake \
         eudev-dev \
-        swig \
-        p8-platform-dev \
+        git \
         linux-headers \
+        p8-platform-dev \
+        swig \
+    && python_version=$(python -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')") \
     && git clone --depth 1 -b "libcec-${LIBCEC_VERSION}" https://github.com/Pulse-Eight/libcec \
     && cd libcec \
     && git apply ../libcec-fix-null-return.patch \
     && git apply ../libcec-python313.patch \
     && mkdir build \
     && cd build \
-    && cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr/local \
-        -DPYTHON_LIBRARY="/usr/local/lib/libpython3.13.so" \
-        -DPYTHON_INCLUDE_DIR="/usr/local/include/python3.13" \
+    && cmake -DCMAKE_INSTALL_PREFIX:PATH=/opt/libcec \
+        -DPYTHON_LIBRARY="/usr/local/lib/libpython${python_version}.so" \
+        -DPYTHON_INCLUDE_DIR="/usr/local/include/python${python_version}" \
         -DHAVE_LINUX_API=1 \
         .. \
     && make -j"$(nproc)" \
-    && make install \
-    && echo "cec" > "/usr/local/lib/python3.13/site-packages/cec.pth" \
-    && apk del .build-dependencies \
-    && rm -rf \
-        /usr/src/libcec \
-        /usr/src/libcec-fix-null-return.patch \
-        /usr/src/libcec-python313.patch
+    && make install
 
+
+# Build stage for PicoTTS, installs to /opt/picotts
 # PicoTTS - it has no specific version - commit should be taken from build.json
-RUN apk add --no-cache \
-        popt \
-    && apk add --no-cache --virtual .build-dependencies \
-       automake \
+FROM ${BUILD_FROM} AS picotts-builder
+ARG PICOTTS_HASH
+ARG BUILD_FROM
+WORKDIR /tmp/
+RUN --mount=type=cache,target=/etc/apk/cache,sharing=locked,id=picotts-builder-${BUILD_FROM}-${PICOTTS_HASH} \
+    apk add \
        autoconf \
+       automake \
+       build-base \
+       git \
        libtool \
        popt-dev \
-       build-base \
     && git clone https://github.com/naggety/picotts.git pico \
     && cd pico/pico \
     && git reset --hard "${PICOTTS_HASH}" \
     && ./autogen.sh \
+    && mkdir /opt/picotts \
     && ./configure \
          --disable-static \
+         --prefix=/opt/picotts \
     && make \
-    && make install \
-    && apk del .build-dependencies \
-    && rm -rf /usr/src/pico
+    && make install
 
-# Telldus
-COPY patches/telldus-fix-gcc-11-issues.patch /usr/src/
-COPY patches/telldus-fix-alpine-3-17-issues.patch /usr/src/
-RUN \
-    apk add --no-cache \
-        confuse \
-        libftdi1 \
-    && apk add --no-cache --virtual .build-dependencies \
+
+# Build stage for Telldus, installs to /opt/telldus
+FROM ${BUILD_FROM} AS telldus-builder
+ARG TELLDUS_COMMIT
+ARG BUILD_FROM
+WORKDIR /tmp/
+COPY patches/telldus-fix-gcc-11-issues.patch /tmp/
+COPY patches/telldus-fix-alpine-3-17-issues.patch /tmp/
+RUN --mount=type=cache,target=/etc/apk/cache,sharing=locked,id=telldus-builder-${BUILD_FROM}-${TELLDUS_COMMIT} \
+    apk add \
         argp-standalone \
         build-base \
         cmake \
         confuse-dev \
         doxygen \
+        git \
         libftdi1-dev \
     && git clone https://github.com/telldus/telldus \
     && cd telldus \
@@ -134,16 +110,70 @@ RUN \
     && git apply ../telldus-fix-gcc-11-issues.patch \
     && git apply ../telldus-fix-alpine-3-17-issues.patch \
     && cd telldus-core \
+    && mkdir /opt/telldus \
     && cmake . -DBUILD_LIBTELLDUS-CORE=ON \
         -DBUILD_TDADMIN=OFF -DBUILD_TDTOOL=OFF -DGENERATE_MAN=OFF \
         -DFORCE_COMPILE_FROM_TRUNK=ON \
+        -DCMAKE_INSTALL_PREFIX:PATH=/opt/telldus \
     && make -j"$(nproc)" \
-    && make install \
-    && apk del .build-dependencies \
-    && rm -rf \
-        /usr/src/telldus \
-        /usr/src/telldus-fix-gcc-11-issues.patch \
-        /usr/src/telldus-fix-alpine-3-17-issues.patch
+    && make install
+
+
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG QEMU_CPU
+ARG BUILD_FROM
+
+##
+# Install component packages
+RUN --mount=type=cache,target=/etc/apk/cache,sharing=locked,id=main-builder-${BUILD_FROM} \
+    apk add \
+        bluez \
+        bluez-deprecated \
+        bluez-libs \
+        confuse \
+        curl \
+        eudev-libs \
+        ffmpeg \
+        grep \
+        hwdata-usb \
+        imlib2 \
+        iperf3 \
+        libftdi1 \
+        libgpiod \
+        libpulse \
+        libturbojpeg \
+        libzbar \
+        mariadb-connector-c \
+        net-tools \
+        nmap \
+        openssh-client \
+        p8-platform \
+        pianobar \
+        popt \
+        pulseaudio-alsa \
+        socat
+
+WORKDIR /usr/src/
+
+####
+## Copy from pip builder
+COPY --link --from=pip-install-builder /root/.local/ /root/.local/
+
+# Copy from ssocr builder
+COPY --link --from=ssocr-builder /opt/ssocr/ /usr/local/
+
+# Copy from libcec builder
+COPY --link --from=libcec-builder /opt/libcec/ /usr/local/
+RUN python_version=$(python -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')") \
+    && echo "cec" > "/usr/local/lib/python${python_version}/site-packages/cec.pth"
+
+# Copy from picotts builder
+COPY --link --from=picotts-builder /opt/picotts/ /usr/local/
+
+# Copy from Telldus builder
+COPY --link --from=telldus-builder /opt/telldus/ /usr/local/
 
 ###
 # Base S6-Overlay


### PR DESCRIPTION
## Why

Hello! I've noticed the docker image is quite hefty, and I was curious if I could improve it a bit. After taking a look, I realized I couldn't help much with reducing the image size 😆 .... but I thought it might be possible to improve layer reuse between builds. In the end, this feature branch is only 7.98mb smaller then whats on `master`, but I believe layer reuse is now a possibility depending on how the builds and caching are set up.

If no one thinks this PR provides any value, that’s no problem! It does introduce a bit more complexity, so I totally understand. Anyway, on to the changes I made:

## What

I've moved each major build phase into its own builder stage using multi-stage builds: `ssocr`, `pip`, `libcec`, `PicoTTS`, and `Telldus`. The results of those builder stages are then copied out into the 'main' stage. All temporary files were already being pruned nicely, so again, no real space savings. However, using the `COPY --link` command from the builder stages enables this cool [docker feature](https://docs.docker.com/reference/dockerfile/#benefits-of-using---link):

> Use --link to reuse already built layers in subsequent builds with --cache-from even if the previous layers have changed. This is especially important for multi-stage builds where a COPY --from statement would previously get invalidated if any previous commands in the same stage changed, causing the need to rebuild the intermediate stages again. With --link the layer the previous build generated is reused and merged on top of the new layers. This also means you can easily rebase your images when the base images receive updates, without having to execute the whole build again.

So, if you need to bump a version in `requirements.txt`, using `COPY --link` will allow those other layer - like `ssocr` - to remain unchanged. Pretty cool! If this PR works as expected, I hope that the next time I run `docker compose pull`, it will require fewer layers to be pulled.

Now... there is a bit of a gotcha with all this. This caching logic only works if the builds are correctly set up with caching. For example, `docker-compose` builds cannot create a multi-stage build cache. Looking around, I see `buildx` is being used over at `home-assistant/builder/`, but there was a lot of logic going on, and I couldn't quite follow it all.

So, there's a chance some follow-up changes might be needed before the benefits of this PR can be realized - for example, using `cache-to` and ensuring `mode=max` is set to enable the mutli-stage build cache. But one step at a time - if you all think this is an improvement worth making, we can iterate from here.

## Testing

For testing, I ran the build and verified that it runs. However, that doesn’t fully confirm that the libraries I modified are still being installed correctly. Some follow-up work is definitely required to verify everything is functioning as expected.