### PR TITLE
Re-add git to base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -143,6 +143,7 @@ RUN \
         curl \
         eudev-libs \
         ffmpeg \
+        git \
         grep \
         hwdata-usb \
         imlib2 \


### PR DESCRIPTION
With #343 the image ended up without git installed. This does not seem an intentional change, readd git so it is present in the base image.