### PR TITLE
Update home-assistant/wheels to 2025.09.1

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -60,7 +60,7 @@ jobs:
           fi
 
       - name: Build wheels cp313
-        uses: home-assistant/wheels@2025.09.0
+        uses: home-assistant/wheels@2025.09.1
         if: github.event_name == 'release' || steps.requirements.outputs.changed == 'true'
         with:
           tag: musllinux_1_2


### PR DESCRIPTION
Changelog: https://github.com/home-assistant/wheels/releases/tag/2025.09.1

Needed to fix our builds.

